### PR TITLE
None check before getattr

### DIFF
--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -140,4 +140,6 @@ class Social(object):
         return state
 
     def __getattr__(self, name):
+        if self.app is None and self.datastore is None:
+            return None
         return getattr(self._state, name, None)


### PR DESCRIPTION
if social isn't initialized properly, you will get this:

....
  File "/Users/baran/Developer/argume/venv/lib/python2.7/site-packages/flask_social/core.py", line 146, in **getattr**
    return getattr(self._state, name, None)
  File "/Users/baran/Developer/argume/venv/lib/python2.7/site-packages/flask_social/core.py", line 146, in __getattr__
    return getattr(self._state, name, None)
  File "/Users/baran/Developer/argume/venv/lib/python2.7/site-packages/flask_social/core.py", line 146, in __getattr__
    return getattr(self._state, name, None)
  File "/Users/baran/Developer/argume/venv/lib/python2.7/site-packages/flask_social/core.py", line 146, in __getattr__
    return getattr(self._state, name, None)
RuntimeError: maximum recursion depth exceeded while calling a Python object
