### PR TITLE
Update installation section to always use PyPI

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,13 +41,13 @@ Then install your datastore requirement.
 
 **MongoEngine**::
 
-    $ pip install https://github.com/sbook/flask-mongoengine/tarball/master
+    $ pip install flask-mongoengine
 
 Then install your provider API libraries.
 
 **Facebook**::
 
-    $ pip install http://github.com/pythonforfacebook/facebook-sdk/tarball/master
+    $ pip install facebook-sdk
 
 **Twitter**::
 


### PR DESCRIPTION
I'm assuming at the time the Flask-Social documentation was written,
Flask-MongoEngine and Facebook-SDK weren't on PyPI yet. I can install
from these locations without any issues, so let's simplify these docs.
