### PR TITLE
Allow SOCIAL_<PROVIDER> settings to be None

### DIFF
--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -120,7 +120,7 @@ class Social(object):
         providers = dict()
 
         for key, config in app.config.items():
-            if not key.startswith('SOCIAL_') or key in default_config:
+            if not key.startswith('SOCIAL_') or config is None or key in default_config:
                 continue
 
             suffix = key.lower().replace('social_', '')


### PR DESCRIPTION
With this, you can be explicit about what settings are expected
in your root settings.py file. SOCIAL_FACEBOOK can be None, for
example, and overridden in another file or in the environment.

Here's my personal setup:

```
SOCIAL_TWITTER = {
    'consumer_key': os.environ.get('TWITTER_CONSUMER_KEY'),
    'consumer_secret': os.environ.get('TWITTER_CONSUMER_SECRET'),
} if os.environ.get('TWITTER_CONSUMER_KEY') else None
```

It would be ideal if 'consumer_key' could allow None, but I didn't want
to break the OAuth mechanism in this commit, so this is good enough.
