### PR TITLE
fix connect_callback() so redirect is correct upon failure

### DIFF
--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -145,12 +145,14 @@ def connect_callback(provider_id):
 
     def connect(response):
         cv = get_connection_values_from_oauth_response(provider, response)
-        if cv is None:
-            do_flash('Access was denied by %s' % provider.name, 'error')
-            return redirect(get_url(config_value('CONNECT_DENY_VIEW')))
         return cv
 
-    return connect_handler(provider.authorized_handler(connect)(), provider)
+    cv = provider.authorized_handler(connect)()
+    if cv is None:
+        do_flash('Access was denied by %s' % provider.name, 'error')
+        return redirect(get_url(config_value('CONNECT_DENY_VIEW')))
+
+    return connect_handler(cv, provider)
 
 
 @anonymous_user_required

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Social',
-    version='1.6.1',
+    version='1.6.2',
     url='https://github.com/mattupstate/flask-social',
     license='MIT',
     author='Matthew Wright',


### PR DESCRIPTION
This fixes [Issue 18](https://github.com/mattupstate/flask-social/issues/18).

Since the result of the `connect` function was being handed directly to `connect_handler`, the `redirect` was being consumed as `cv` in `connect_handler`, rather than actually performing the redirect. Moving the check if `cv` is `None` outside of the `connect` function fixes the issue.
