### PR TITLE
fix connect_callback() so redirect is correct upon failure

### DIFF
--- a/flask_social/providers/facebook.py
+++ b/flask_social/providers/facebook.py
@@ -55,7 +55,8 @@ def get_connection_values(response, **kwargs):
         provider_user_id=profile['id'],
         access_token=access_token,
         secret=None,
-        display_name=profile.get('username', profile.get('name')),
+        display_name=profile.get('username', None),
+        full_name = profile.get('name', None),
         profile_url=profile_url,
         image_url=image_url
     )

--- a/flask_social/providers/foursquare.py
+++ b/flask_social/providers/foursquare.py
@@ -60,6 +60,7 @@ def get_connection_values(response, **kwargs):
         access_token=access_token,
         secret=None,
         display_name=profile_url.split('/')[-1:][0],
+        full_name = '%s %s' % (user['firstName'], user['lastName']),
         profile_url=profile_url,
         image_url=image_url
     )

--- a/flask_social/providers/google.py
+++ b/flask_social/providers/google.py
@@ -82,7 +82,8 @@ def get_connection_values(response, **kwargs):
         provider_user_id=profile['id'],
         access_token=access_token,
         secret=None,
-        display_name=profile['displayName'],
-        profile_url=profile['url'],
-        image_url=profile['image']['url']
+        display_name=profile['name'],
+        full_name=profile['name'],
+        profile_url=profile.get('link'),
+        image_url=profile.get('picture')
     )

--- a/flask_social/providers/twitter.py
+++ b/flask_social/providers/twitter.py
@@ -53,6 +53,7 @@ def get_connection_values(response=None, **kwargs):
         access_token=response['oauth_token'],
         secret=response['oauth_token_secret'],
         display_name='@%s' % user.screen_name,
+        full_name = user.name,
         profile_url="http://twitter.com/%s" % user.screen_name,
         image_url=user.profile_image_url
     )

--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -145,12 +145,14 @@ def connect_callback(provider_id):
 
     def connect(response):
         cv = get_connection_values_from_oauth_response(provider, response)
-        if cv is None:
-            do_flash('Access was denied by %s' % provider.name, 'error')
-            return redirect(get_url(config_value('CONNECT_DENY_VIEW')))
         return cv
 
-    return connect_handler(provider.authorized_handler(connect)(), provider)
+    cv = provider.authorized_handler(connect)()
+    if cv is None:
+        do_flash('Access was denied by %s' % provider.name, 'error')
+        return redirect(get_url(config_value('CONNECT_DENY_VIEW')))
+
+    return connect_handler(cv, provider)
 
 
 @anonymous_user_required

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Social',
-    version='1.6.1',
+    version='1.6.2',
     url='https://github.com/mattupstate/flask-social',
     license='MIT',
     author='Matthew Wright',

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -12,7 +12,8 @@ def get_mock_twitter_response():
         'oauth_token_secret': 'the_oauth_token_secret',
         'user_id': '1234',
         'oauth_token': 'the_oauth_token',
-        'screen_name': 'twitter_username'
+        'screen_name': 'twitter_username',
+        'name': 'twitter_name'
     }
 
 
@@ -23,6 +24,7 @@ def get_mock_twitter_connection_values():
         'access_token': 'the_oauth_token',
         'secret': 'the_oauth_token_secret',
         'display_name': '@twitter_username',
+        'full_name': 'twitter_name',
         'profile_url': 'http://twitter.com/twitter_username',
         'image_url': 'https://cdn.twitter.com/something.png'
     }


### PR DESCRIPTION
This fixes Issue 18.

Since the result of the connect function was being handed directly to connect_handler, the redirect was being consumed as cv in connect_handler, rather than actually performing the redirect. Moving the check if cv is None outside of the connect function fixes the issue.
