### PR TITLE
Fix google

### DIFF
--- a/flask_social/providers/google.py
+++ b/flask_social/providers/google.py
@@ -31,9 +31,11 @@ config = {
     'request_token_params': {
         'response_type': 'code',
         'scope': 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/plus.me'
-        #add ' https://www.googleapis.com/auth/userinfo.email' to scope to also get email
+        # add ' https://www.googleapis.com/auth/userinfo.email' to scope to
+        # also get email
     }
 }
+
 
 def _get_api(credentials):
     http = httplib2.Http()
@@ -73,13 +75,15 @@ def get_connection_values(response, **kwargs):
     )
 
     profile = _get_api(credentials).userinfo().get().execute()
+    full_name = ' '.join(
+        (profile['name']['givenName'], profile['name']['familyName']))
     return dict(
         provider_id=config['id'],
         provider_user_id=profile['id'],
         access_token=access_token,
         secret=None,
-        display_name=profile['name'],
-        full_name=profile['name'],
+        display_name=profile['displayName'],
+        full_name=full_name,
         profile_url=profile.get('link'),
         image_url=profile.get('picture')
     )

--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -11,17 +11,17 @@
 from importlib import import_module
 
 from flask import Blueprint, current_app, redirect, request, session, \
-     after_this_request, abort, url_for
+    after_this_request, abort, url_for
 from flask.ext.security import current_user, login_required
 from flask.ext.security.utils import get_post_login_redirect, login_user, \
-     get_url, do_flash
+    get_url, do_flash
 from flask.ext.security.decorators import anonymous_user_required
 from werkzeug.local import LocalProxy
 
 from .signals import connection_removed, connection_created, \
-     connection_failed, login_completed, login_failed
+    connection_failed, login_completed, login_failed
 from .utils import config_value, get_provider_or_404, get_authorize_callback, \
-     get_connection_values_from_oauth_response
+    get_connection_values_from_oauth_response
 
 
 # Convenient references
@@ -118,7 +118,8 @@ def connect_handler(cv, provider):
     :param provider_id: The provider ID the connection shoudl be made to
     """
     cv.setdefault('user_id', current_user.get_id())
-    connection = _datastore.find_connection(**cv)
+    connection = _datastore.find_connection(
+        provider_id=cv['provider_id'], provider_user_id=cv['provider_user_id'])
 
     if connection is None:
         after_this_request(_commit)


### PR DESCRIPTION
The "name" field returned by the google profile is an object of the format 

```
"name": {
  "familyName": "Bonser",
  "givenName": "Paul"
 }
```

This fix turns it into a string instead, and also uses the displayName attribute of the response since it is there and perhaps might be different.

Also, there's a change to only use the provider_id and provider_user_id when doing a lookup for existing connections.
