### PR TITLE
set self.app and self.datastore in init_app

### DIFF
--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -112,7 +112,8 @@ class Social(object):
         :param datastore: Connection datastore instance
         """
 
-        datastore = datastore or self.datastore
+        self.app = app or self.app
+        self.datastore = datastore = datastore or self.datastore
 
         for key, value in default_config.items():
             app.config.setdefault(key, value)


### PR DESCRIPTION
If app and datastore were not set in the constructor, they should be set when init_app is called.
