### PR TITLE
reauth: check for updated oauth tokens, update if necessary

### DIFF
--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -11,7 +11,7 @@
 from importlib import import_module
 
 from flask import current_app
-from flask.ext.oauth import OAuthRemoteApp as BaseRemoteApp
+from flask_oauthlib.client import OAuthRemoteApp as BaseRemoteApp
 from flask.ext.security import current_user
 from werkzeug.local import LocalProxy
 

--- a/flask_social/providers/facebook.py
+++ b/flask_social/providers/facebook.py
@@ -60,3 +60,9 @@ def get_connection_values(response, **kwargs):
         profile_url=profile_url,
         image_url=image_url
     )
+
+def get_token_pair_from_response(response):
+    return dict(
+        access_token = response.get('access_token', None),
+        secret = None
+    )

--- a/flask_social/providers/foursquare.py
+++ b/flask_social/providers/foursquare.py
@@ -64,3 +64,9 @@ def get_connection_values(response, **kwargs):
         profile_url=profile_url,
         image_url=image_url
     )
+
+def get_token_pair_from_response(response):
+    return dict(
+        access_token = response.get('access_token', None),
+        secret = None
+    )

--- a/flask_social/providers/foursquare.py
+++ b/flask_social/providers/foursquare.py
@@ -22,12 +22,6 @@ config = {
     'request_token_url': None,
     'access_token_url': 'https://foursquare.com/oauth2/access_token',
     'authorize_url': 'https://foursquare.com/oauth2/authenticate',
-    'access_token_params': {
-        'grant_type': 'authorization_code'
-    },
-    'request_token_params': {
-        'response_type': 'code'
-    }
 }
 
 

--- a/flask_social/providers/google.py
+++ b/flask_social/providers/google.py
@@ -25,11 +25,7 @@ config = {
     'access_token_url': 'https://accounts.google.com/o/oauth2/token',
     'request_token_url': None,
     'access_token_method': 'POST',
-    'access_token_params': {
-        'grant_type': 'authorization_code'
-    },
     'request_token_params': {
-        'response_type': 'code',
         'scope': 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/plus.me'
         #add ' https://www.googleapis.com/auth/userinfo.email' to scope to also get email
     }

--- a/flask_social/providers/google.py
+++ b/flask_social/providers/google.py
@@ -83,3 +83,9 @@ def get_connection_values(response, **kwargs):
         profile_url=profile.get('link'),
         image_url=profile.get('picture')
     )
+
+def get_token_pair_from_response(response):
+    return dict(
+        access_token = response.get('access_token', None),
+        secret = None
+    )

--- a/flask_social/providers/twitter.py
+++ b/flask_social/providers/twitter.py
@@ -57,3 +57,9 @@ def get_connection_values(response=None, **kwargs):
         profile_url="http://twitter.com/%s" % user.screen_name,
         image_url=user.profile_image_url
     )
+
+def get_token_pair_from_response(response):
+    return dict(
+        access_token = response.get('oauth_token', None),
+        secret = response.get('oauth_token_secret', None)
+    )

--- a/flask_social/utils.py
+++ b/flask_social/utils.py
@@ -48,6 +48,9 @@ def get_connection_values_from_oauth_response(provider, oauth_response):
         consumer_key=provider.consumer_key,
         consumer_secret=provider.consumer_secret)
 
+def get_token_pair_from_oauth_response(provider, oauth_response):
+    module = import_module(provider.module)
+    return module.get_token_pair_from_response(oauth_response)
 
 def get_config(app):
     """Conveniently get the social configuration for the specified

--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -21,7 +21,7 @@ from werkzeug.local import LocalProxy
 from .signals import connection_removed, connection_created, \
      connection_failed, login_completed, login_failed
 from .utils import config_value, get_provider_or_404, get_authorize_callback, \
-     get_connection_values_from_oauth_response
+     get_connection_values_from_oauth_response, get_token_pair_from_oauth_response
 
 
 # Convenient references
@@ -163,6 +163,11 @@ def login_handler(response, provider, query):
 
     if connection:
         after_this_request(_commit)
+        token_pair = get_token_pair_from_oauth_response(provider, response)
+        if (token_pair['access_token'] != connection.access_token or
+            token_pair['secret'] != connection.secret):
+            connection.access_token = token_pair['access_token']
+            connection.secret = token_pair['secret']
         user = connection.user
         login_user(user)
         key = _social.post_oauth_login_session_key

--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -176,6 +176,7 @@ def login_handler(response, provider, query):
             token_pair['secret'] != connection.secret):
             connection.access_token = token_pair['access_token']
             connection.secret = token_pair['secret']
+            _datastore.put(connection)
         user = connection.user
         login_user(user)
         key = _social.post_oauth_login_session_key

--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -14,7 +14,7 @@ from flask import Blueprint, current_app, redirect, request, session, \
      after_this_request, abort, url_for
 from flask.ext.security import current_user, login_required
 from flask.ext.security.utils import get_post_login_redirect, login_user, \
-     get_url, do_flash
+     logout_user, get_url, do_flash
 from flask.ext.security.decorators import anonymous_user_required
 from werkzeug.local import LocalProxy
 
@@ -59,6 +59,14 @@ def connect(provider_id):
     session[config_value('POST_OAUTH_CONNECT_SESSION_KEY')] = pc
     return provider.authorize(callback_url)
 
+
+@login_required
+def reconnect(provider_id):
+    """Tokens automatically refresh with login.
+    Logs user out and starts provider login OAuth flow
+    """
+    logout_user()
+    return login(provider_id)
 
 @login_required
 def remove_all_connections(provider_id):
@@ -235,5 +243,8 @@ def create_blueprint(state, import_name):
 
     bp.route('/connect/<provider_id>/<provider_user_id>',
              methods=['DELETE'])(remove_connection)
+
+    bp.route('/reconnect/<provider_id>',
+             methods=['POST'])(reconnect)
 
     return bp

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -201,6 +201,13 @@ class TwitterSocialTests(SocialTest):
         self._post('/connect/twitter')
         r = self._get('/connect/twitter?oauth_token=oauth_token&oauth_verifier=oauth_verifier', follow_redirects=True)
         self.assertIn('Connection established to Twitter', r.data)
+        user = self.app.get_user()
+        connection = [c for c in user.connections if c.provider_id == 'twitter'][0]
+        self.assertEqual(connection.access_token,
+                         get_mock_twitter_connection_values()['access_token'])
+        self.assertEqual(connection.secret,
+                         get_mock_twitter_connection_values()['secret'])
+
         self._get('/logout')
         self._post('/login/twitter')
         r = self._get('/login/twitter?oauth_token=oauth_token&oauth_verifier=oauth_verifier', follow_redirects=True)
@@ -217,12 +224,12 @@ class TwitterSocialTests(SocialTest):
     @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
-    def test_connected_twitter_login_update_token(self,
-                                                  mock_authorize,
-                                                  mock_handle_oauth1_response,
-                                                  mock_get_token_pair_from_response,
-                                                  mock_get_connection_values,
-                                                  mock_get_twitter_api):
+    def test_reconnect_twitter_token(self,
+                                     mock_authorize,
+                                     mock_handle_oauth1_response,
+                                     mock_get_token_pair_from_response,
+                                     mock_get_connection_values,
+                                     mock_get_twitter_api):
         mock_get_connection_values.return_value = get_mock_twitter_connection_values()
         mock_get_token_pair_from_response.return_value = get_mock_twitter_updated_token_pair()
         mock_authorize.return_value = 'Should be a redirect'
@@ -233,6 +240,13 @@ class TwitterSocialTests(SocialTest):
         self._post('/connect/twitter')
         r = self._get('/connect/twitter?oauth_token=oauth_token&oauth_verifier=oauth_verifier', follow_redirects=True)
         self.assertIn('Connection established to Twitter', r.data)
+        user = self.app.get_user()
+        connection = [c for c in user.connections if c.provider_id == 'twitter'][0]
+        self.assertEqual(connection.access_token,
+                         get_mock_twitter_connection_values()['access_token'])
+        self.assertEqual(connection.secret,
+                         get_mock_twitter_connection_values()['secret'])
+
         self._post('/reconnect/twitter')
         r = self._get('/login/twitter?oauth_token=oauth_token&oauth_verifier=oauth_verifier', follow_redirects=True)
         self.assertIn("Hello matt@lp.com", r.data)

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -101,8 +101,8 @@ class SocialTest(unittest.TestCase):
 class TwitterSocialTests(SocialTest):
 
     @mock.patch('flask_social.providers.twitter.get_connection_values')
-    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.authorize')
     def test_connect_twitter(self,
                              mock_authorize,
                              mock_handle_oauth1_response,
@@ -119,8 +119,8 @@ class TwitterSocialTests(SocialTest):
         self.assertIn('Connection established to Twitter', r.data)
 
     @mock.patch('flask_social.providers.twitter.get_connection_values')
-    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.authorize')
     def test_double_connect_twitter(self,
                                     mock_authorize,
                                     mock_handle_oauth1_response,
@@ -138,8 +138,8 @@ class TwitterSocialTests(SocialTest):
 
     @mock.patch('flask_social.providers.twitter.get_connection_values')
     @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.authorize')
     def test_unconnected_twitter_login(self,
                                        mock_authorize,
                                        mock_handle_oauth1_response,
@@ -157,8 +157,8 @@ class TwitterSocialTests(SocialTest):
     @mock.patch('flask_social.providers.twitter.get_api')
     @mock.patch('flask_social.providers.twitter.get_connection_values')
     @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.authorize')
     def test_connected_twitter_login(self,
                                      mock_authorize,
                                      mock_handle_oauth1_response,
@@ -183,8 +183,8 @@ class TwitterSocialTests(SocialTest):
     @mock.patch('flask_social.providers.twitter.get_api')
     @mock.patch('flask_social.providers.twitter.get_connection_values')
     @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.authorize')
     def test_connected_twitter_login_update_token(self,
                                                   mock_authorize,
                                                   mock_handle_oauth1_response,
@@ -222,8 +222,8 @@ class TwitterSocialTests(SocialTest):
     @mock.patch('flask_social.providers.twitter.get_api')
     @mock.patch('flask_social.providers.twitter.get_connection_values')
     @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.authorize')
     def test_reconnect_twitter_token(self,
                                      mock_authorize,
                                      mock_handle_oauth1_response,
@@ -258,8 +258,8 @@ class TwitterSocialTests(SocialTest):
                          get_mock_twitter_updated_token_pair()['secret'])
 
     @mock.patch('flask_social.providers.twitter.get_connection_values')
-    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
-    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauthlib.client.OAuthRemoteApp.authorize')
     def test_remove_connection(self,
                                mock_authorize,
                                mock_handle_oauth1_response,

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -26,6 +26,17 @@ def get_mock_twitter_connection_values():
         'image_url': 'https://cdn.twitter.com/something.png'
     }
 
+def get_mock_twitter_token_pair():
+    return {
+        'access_token': 'the_oauth_token',
+        'secret': 'the_oauth_token_secret'
+        }
+
+def get_mock_twitter_updated_token_pair():
+    return {
+        'access_token': 'the_updated_oauth_token',
+        'secret': 'the_updated_oauth_token_secret'
+        }
 
 class SocialTest(unittest.TestCase):
 
@@ -92,7 +103,10 @@ class TwitterSocialTests(SocialTest):
     @mock.patch('flask_social.providers.twitter.get_connection_values')
     @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
-    def test_connect_twitter(self, mock_authorize, mock_handle_oauth1_response, mock_get_connection_values):
+    def test_connect_twitter(self,
+                             mock_authorize,
+                             mock_handle_oauth1_response,
+                             mock_get_connection_values):
         mock_get_connection_values.return_value = get_mock_twitter_connection_values()
         mock_authorize.return_value = 'Should be a redirect'
         mock_handle_oauth1_response.return_value = get_mock_twitter_response()
@@ -107,7 +121,10 @@ class TwitterSocialTests(SocialTest):
     @mock.patch('flask_social.providers.twitter.get_connection_values')
     @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
-    def test_double_connect_twitter(self, mock_authorize, mock_handle_oauth1_response, mock_get_connection_values):
+    def test_double_connect_twitter(self,
+                                    mock_authorize,
+                                    mock_handle_oauth1_response,
+                                    mock_get_connection_values):
         mock_get_connection_values.return_value = get_mock_twitter_connection_values()
         mock_authorize.return_value = 'Should be a redirect'
         mock_handle_oauth1_response.return_value = get_mock_twitter_response()
@@ -120,10 +137,16 @@ class TwitterSocialTests(SocialTest):
         self.assertIn('A connection is already established with', r.data)
 
     @mock.patch('flask_social.providers.twitter.get_connection_values')
+    @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
-    def test_unconnected_twitter_login(self, mock_authorize, mock_handle_oauth1_response, mock_get_connection_values):
+    def test_unconnected_twitter_login(self,
+                                       mock_authorize,
+                                       mock_handle_oauth1_response,
+                                       mock_get_token_pair_from_response,
+                                       mock_get_connection_values):
         mock_get_connection_values.return_value = get_mock_twitter_connection_values()
+        mock_get_token_pair_from_response.return_value = get_mock_twitter_token_pair()
         mock_authorize.return_value = 'Should be a redirect'
         mock_handle_oauth1_response.return_value = get_mock_twitter_response()
 
@@ -133,10 +156,17 @@ class TwitterSocialTests(SocialTest):
 
     @mock.patch('flask_social.providers.twitter.get_api')
     @mock.patch('flask_social.providers.twitter.get_connection_values')
+    @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
-    def test_connected_twitter_login(self, mock_authorize, mock_handle_oauth1_response,mock_get_twitter_api, mock_get_connection_values):
+    def test_connected_twitter_login(self,
+                                     mock_authorize,
+                                     mock_handle_oauth1_response,
+                                     mock_get_token_pair_from_response,
+                                     mock_get_connection_values,
+                                     mock_get_twitter_api):
         mock_get_connection_values.return_value = get_mock_twitter_connection_values()
+        mock_get_token_pair_from_response.return_value = get_mock_twitter_token_pair()
         mock_authorize.return_value = 'Should be a redirect'
         mock_handle_oauth1_response.return_value = get_mock_twitter_response()
         mock_get_twitter_api.return_value = get_mock_twitter_connection_values()
@@ -150,10 +180,45 @@ class TwitterSocialTests(SocialTest):
         r = self._get('/login/twitter?oauth_token=oauth_token&oauth_verifier=oauth_verifier', follow_redirects=True)
         self.assertIn("Hello matt@lp.com", r.data)
 
+    @mock.patch('flask_social.providers.twitter.get_api')
+    @mock.patch('flask_social.providers.twitter.get_connection_values')
+    @mock.patch('flask_social.providers.twitter.get_token_pair_from_response')
+    @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
+    @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
+    def test_connected_twitter_login_update_token(self,
+                                                  mock_authorize,
+                                                  mock_handle_oauth1_response,
+                                                  mock_get_token_pair_from_response,
+                                                  mock_get_connection_values,
+                                                  mock_get_twitter_api):
+        mock_get_connection_values.return_value = get_mock_twitter_connection_values()
+        mock_get_token_pair_from_response.return_value = get_mock_twitter_updated_token_pair()
+        mock_authorize.return_value = 'Should be a redirect'
+        mock_handle_oauth1_response.return_value = get_mock_twitter_response()
+        mock_get_twitter_api.return_value = get_mock_twitter_connection_values()
+
+        self.authenticate()
+        self._post('/connect/twitter')
+        r = self._get('/connect/twitter?oauth_token=oauth_token&oauth_verifier=oauth_verifier', follow_redirects=True)
+        self.assertIn('Connection established to Twitter', r.data)
+        self._get('/logout')
+        self._post('/login/twitter')
+        r = self._get('/login/twitter?oauth_token=oauth_token&oauth_verifier=oauth_verifier', follow_redirects=True)
+        self.assertIn("Hello matt@lp.com", r.data)
+        user = self.app.get_user()
+        connection = [c for c in user.connections if c.provider_id == 'twitter'][0]
+        self.assertEqual(connection.access_token,
+                         get_mock_twitter_updated_token_pair()['access_token'])
+        self.assertEqual(connection.secret,
+                         get_mock_twitter_updated_token_pair()['secret'])
+
     @mock.patch('flask_social.providers.twitter.get_connection_values')
     @mock.patch('flask_oauth.OAuthRemoteApp.handle_oauth1_response')
     @mock.patch('flask_oauth.OAuthRemoteApp.authorize')
-    def test_remove_connection(self, mock_authorize, mock_handle_oauth1_response, mock_get_connection_values):
+    def test_remove_connection(self,
+                               mock_authorize,
+                               mock_handle_oauth1_response,
+                               mock_get_connection_values):
         mock_get_connection_values.return_value = get_mock_twitter_connection_values()
         mock_authorize.return_value = 'Should be a redirect'
         mock_handle_oauth1_response.return_value = get_mock_twitter_response()

--- a/tests/test_app/mongoengine.py
+++ b/tests/test_app/mongoengine.py
@@ -63,6 +63,7 @@ def create_app(auth_config=None, debug=True):
             m.drop_collection()
         populate_data()
 
+    app.get_user = lambda: User.objects().first()
     return app
 
 if __name__ == '__main__':

--- a/tests/test_app/peewee_app.py
+++ b/tests/test_app/peewee_app.py
@@ -69,6 +69,8 @@ def create_app(config=None, debug=True):
             Model.create_table(fail_silently=True)
         populate_data()
 
+    app.get_user = lambda: User.select().get()
+
     return app
 
 if __name__ == '__main__':

--- a/tests/test_app/sqlalchemy.py
+++ b/tests/test_app/sqlalchemy.py
@@ -61,6 +61,8 @@ def create_app(config=None, debug=True):
         db.create_all()
         populate_data()
 
+
+    app.get_user = lambda: User.query.first()
     return app
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added test for coverage for this change. Test passes for SQLAlchemy app, but not for MongoDB or Peewee apps. The `after_this_request(_commit)` doesn't seem to take for those two, and I'm not sure exactly how to add the updated `connection` object to the abstracted "session" (or if that even makes sense in this abstraction).
