### PR TITLE
using SOCIAL_APP_URL to provide a proper callback url 

### DIFF
--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -33,7 +33,7 @@ default_config = {
     'SOCIAL_CONNECT_DENY_VIEW': '/',
     'SOCIAL_POST_OAUTH_CONNECT_SESSION_KEY': 'post_oauth_connect_url',
     'SOCIAL_POST_OAUTH_LOGIN_SESSION_KEY': 'post_oauth_login_url',
-    'SOCIAL_APP_URL': 'http://localhost'
+    'SOCIAL_APP_URL': None,
 }
 
 

--- a/flask_social/utils.py
+++ b/flask_social/utils.py
@@ -32,9 +32,10 @@ def get_authorize_callback(endpoint, provider_id):
 
     param: endpoint: Absolute path to append to the application's host
     """
+    url_root = current_app.config['SOCIAL_APP_URL'] or request.url_root[:-1]
     endpoint_prefix = config_value('BLUEPRINT_NAME')
     url = url_for(endpoint_prefix + '.' + endpoint, provider_id=provider_id)
-    return request.url_root[:-1] + url
+    return url_root + url
 
 
 def get_connection_values_from_oauth_response(provider, oauth_response):


### PR DESCRIPTION
I ran in to the problem of the callback URLs having localhost:5000 (`request.url_root[:-1]`) in them.  Without having to use Flask's SERVER_NAME option, I decided to using the SOCIAL_APP_URL variable that was added to the app.config by default and not seemingly used anywhere else.  I like the idea of using SOCIAL_APP_URL over SERVER_NAME since only the callbacks need full urls.

I changed the behavior such that SOCIAL_APP_URL defaults to None.  Thus, if not SOCIA_APP_URL is given, then request.url_root[:-1] is used for generating the callback urls.
