### PR TITLE
Fixed google connection name processing

### DIFF
--- a/flask_social/providers/google.py
+++ b/flask_social/providers/google.py
@@ -69,13 +69,15 @@ def get_connection_values(response, **kwargs):
     )
 
     profile = _get_api(credentials).userinfo().get().execute()
+    name_parts = profile['name']
+    
     return dict(
         provider_id=config['id'],
         provider_user_id=profile['id'],
         access_token=access_token,
         secret=None,
-        display_name=profile['name'],
-        full_name=profile['name'],
+        display_name= '%s %s' % (name_parts['givenName'], name_parts['familyName']),
+        full_name= '%s %s' % (name_parts['givenName'], name_parts['familyName']),
         profile_url=profile.get('link'),
         image_url=profile.get('picture'),
         email=profile.get('email'),


### PR DESCRIPTION
Name is now an object in the Google+ API that contains `name.givenName` (first name) and `name.familyName` (last name). Adjusting the method so it doesn't throw an exception when creating a user into the datastore.
