### PR TITLE
Use absolute URL for redirect_url. Excepts that SERVER_NAME variable is ...

### DIFF
--- a/flask_social/utils.py
+++ b/flask_social/utils.py
@@ -33,8 +33,8 @@ def get_authorize_callback(endpoint, provider_id):
     param: endpoint: Absolute path to append to the application's host
     """
     endpoint_prefix = config_value('BLUEPRINT_NAME')
-    url = url_for(endpoint_prefix + '.' + endpoint, provider_id=provider_id)
-    return request.url_root[:-1] + url
+    url = url_for(endpoint_prefix + '.' + endpoint, provider_id=provider_id, _external=True)
+    return url
 
 
 def get_connection_values_from_oauth_response(provider, oauth_response):


### PR DESCRIPTION
...configured.

I have a multiple flask applications, frontend and administration.

wsgy.py is something like that:

`application = DispatcherMiddleware(frontend.create_app(), {"/administration": administration.create_app()})`

Queries in administration module adds double /administration slash, see example:

Currently (not patched code) returns `localhost:5000/administration/administration/connect/google` url and this url returns 404.
But correct url is: `localhost:5000/administration/connect/google`.
