### PR TITLE
Fix init

### DIFF
--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -137,9 +137,6 @@ class Social(object):
         app.register_blueprint(create_blueprint(state, __name__))
         app.extensions['social'] = state
 
-        if self.app is None:
-            self.app = app
-
         if self.datastore is None and datastore is not None:
             self.datastore = datastore
 

--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -103,7 +103,7 @@ class Social(object):
         self.datastore = datastore
 
         if app is not None and datastore is not None:
-            self._state = self.init_app(app, datastore)
+            self.init_app(app, datastore)
 
     def init_app(self, app, datastore=None):
         """Initialize the application with the Social extension
@@ -120,7 +120,7 @@ class Social(object):
         providers = dict()
 
         for key, config in app.config.items():
-            if not key.startswith('SOCIAL_') or config is None or key in default_config:
+            if not key.startswith('SOCIAL_') or key in default_config:
                 continue
 
             suffix = key.lower().replace('social_', '')
@@ -136,6 +136,14 @@ class Social(object):
 
         app.register_blueprint(create_blueprint(state, __name__))
         app.extensions['social'] = state
+
+        if self.app is None:
+            self.app = app
+
+        if self.datastore is None and datastore is not None:
+            self.datastore = datastore
+
+        self._state = state
 
         return state
 


### PR DESCRIPTION
Ensures that init_app correctly initializes the extension by assigning the `datastore` and `_state` to `self`

This makes the extension correctly support the factory pattern as described in http://flask.pocoo.org/docs/0.10/extensiondev/
