### PR TITLE
Email from facebook fix

### DIFF
--- a/flask_social/providers/facebook.py
+++ b/flask_social/providers/facebook.py
@@ -46,7 +46,7 @@ def get_connection_values(response, **kwargs):
 
     access_token = response['access_token']
     graph = facebook.GraphAPI(access_token)
-    profile = graph.get_object("me")
+    profile = graph.get_object("me", fields="name,email")
     profile_url = "http://facebook.com/profile.php?id=%s" % profile['id']
     image_url = "http://graph.facebook.com/%s/picture" % profile['id']
 


### PR DESCRIPTION
Facebook api required passing fields="email" in order to actually return the email - also added name in there for good measure.
