### PR TITLE
`flask.ext` deprecation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,8 +122,8 @@ hypothetical profile page instead of Flask-Security's default of the root
 index::
 
     # ... other required imports ...
-    from flask.ext.social import Social
-    from flask.ext.social.datastore import SQLAlchemyConnectionDatastore
+    from flask_social import Social
+    from flask_social.datastore import SQLAlchemyConnectionDatastore
 
     # ... create the app ...
 

--- a/flask_social/__init__.py
+++ b/flask_social/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social
-    ~~~~~~~~~~~~~~~~
+    flask_social
+    ~~~~~~~~~~~~
 
     Flask-Social is a Flask extension that aims to add simple OAuth provider
     integration for Flask-Security

--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -12,7 +12,7 @@ from importlib import import_module
 
 from flask import current_app
 from flask_oauthlib.client import OAuthRemoteApp as BaseRemoteApp
-from flask.ext.security import current_user
+from flask_security import current_user
 from werkzeug.local import LocalProxy
 
 from .utils import get_config, update_recursive

--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.core
-    ~~~~~~~~~~~~~~~~~~~~~
+    flask_social.core
+    ~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social core
 

--- a/flask_social/datastore.py
+++ b/flask_social/datastore.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.datastore
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.datastore
+    ~~~~~~~~~~~~~~~~~~~~~~
 
     This module contains an abstracted social connection datastore.
 

--- a/flask_social/providers/facebook.py
+++ b/flask_social/providers/facebook.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.providers.facebook
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.providers.facebook
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social facebook code
 

--- a/flask_social/providers/foursquare.py
+++ b/flask_social/providers/foursquare.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.providers.foursquare
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.providers.foursquare
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social foursquare code
 

--- a/flask_social/providers/google.py
+++ b/flask_social/providers/google.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.providers.google
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.providers.google
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social google code
 

--- a/flask_social/providers/twitter.py
+++ b/flask_social/providers/twitter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.providers.twitter
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.providers.twitter
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social twitter code
 

--- a/flask_social/providers/vk.py
+++ b/flask_social/providers/vk.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.providers.vk
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.providers.vk
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social vkontakte code
 

--- a/flask_social/signals.py
+++ b/flask_social/signals.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.signals
-    ~~~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.signals
+    ~~~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social signals
 

--- a/flask_social/utils.py
+++ b/flask_social/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.utils
-    ~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.utils
+    ~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social utils
 

--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.social.views
-    ~~~~~~~~~~~~~~~~~~~~~~
+    flask_social.views
+    ~~~~~~~~~~~~~~~~~~
 
     This module contains the Flask-Social views
 

--- a/flask_social/views.py
+++ b/flask_social/views.py
@@ -12,10 +12,10 @@ from importlib import import_module
 
 from flask import (Blueprint, current_app, redirect, request, session,
                    after_this_request, abort, url_for)
-from flask.ext.security import current_user, login_required
-from flask.ext.security.utils import (get_post_login_redirect, login_user,
-                                      logout_user, get_url, do_flash)
-from flask.ext.security.decorators import anonymous_user_required
+from flask_security import current_user, login_required
+from flask_security.utils import (get_post_login_redirect, login_user,
+                                  logout_user, get_url, do_flash)
+from flask_security.decorators import anonymous_user_required
 from werkzeug.local import LocalProxy
 
 from .signals import (connection_removed, connection_created,

--- a/tests/test_app/__init__.py
+++ b/tests/test_app/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from flask import Flask, render_template, current_app
-from flask.ext.security import login_required
+from flask_security import login_required
 from werkzeug import url_decode
 
 class Config(object):

--- a/tests/test_app/mongoengine.py
+++ b/tests/test_app/mongoengine.py
@@ -6,10 +6,10 @@ import os
 sys.path.pop(0)
 sys.path.insert(0, os.getcwd())
 
-from flask.ext.mongoengine import MongoEngine
-from flask.ext.security import Security, UserMixin, RoleMixin, \
+from flask_mongoengine import MongoEngine
+from flask_security import Security, UserMixin, RoleMixin, \
      MongoEngineUserDatastore
-from flask.ext.social import Social, MongoEngineConnectionDatastore
+from flask_social import Social, MongoEngineConnectionDatastore
 
 from tests.test_app import create_app as create_base_app, populate_data
 

--- a/tests/test_app/peewee_app.py
+++ b/tests/test_app/peewee_app.py
@@ -7,9 +7,9 @@ sys.path.pop(0)
 sys.path.insert(0, os.getcwd())
 
 from flask_peewee.db import Database
-from flask.ext.security import Security, UserMixin, RoleMixin, \
+from flask_security import Security, UserMixin, RoleMixin, \
     PeeweeUserDatastore
-from flask.ext.social import Social, PeeweeConnectionDatastore
+from flask_social import Social, PeeweeConnectionDatastore
 from peewee import *
 
 from tests.test_app import create_app as create_base_app, populate_data

--- a/tests/test_app/sqlalchemy.py
+++ b/tests/test_app/sqlalchemy.py
@@ -6,10 +6,10 @@ import os
 sys.path.pop(0)
 sys.path.insert(0, os.getcwd())
 
-from flask.ext.security import Security, UserMixin, RoleMixin, \
+from flask_security import Security, UserMixin, RoleMixin, \
      SQLAlchemyUserDatastore
-from flask.ext.social import Social, SQLAlchemyConnectionDatastore
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_social import Social, SQLAlchemyConnectionDatastore
+from flask_sqlalchemy import SQLAlchemy
 
 from tests.test_app import create_app as create_base_app, populate_data
 


### PR DESCRIPTION
The `flask.ext` namespace was deprecated in Flask 0.11.
