### PR TITLE
Update core.py

### DIFF
--- a/flask_social/core.py
+++ b/flask_social/core.py
@@ -12,7 +12,7 @@ from importlib import import_module
 
 from flask import current_app
 from flask_oauthlib.client import OAuthRemoteApp as BaseRemoteApp
-from flask.ext.security import current_user
+from flask_security import current_user
 from werkzeug.local import LocalProxy
 
 from .utils import get_config, update_recursive


### PR DESCRIPTION
ExtDeprecationWarning: Importing flask.ext.security is deprecated, use flask_security instead.